### PR TITLE
Add two scripts for apply/revert OpenFlow mode on Inception worker

### DIFF
--- a/bin/inception_apply.sh
+++ b/bin/inception_apply.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+# Usage: ./inception_apply.sh <controller_ip>
+
+controller_ip=$1
+
+bridge_name=obr1
+
+echo $controller_ip
+
+# Connect the OVS to the controller
+ovs-vsctl set-controller $bridge_name tcp:$controller_ip:6633
+
+# Configure the controller to be out of band.  With controller "in
+# band", Open vSwitch sets up special "hidden" flows to make sure that
+# traffic can make it back and forth between OVS and the controller.
+# These hidden flows are removed when controller is set "out of band"
+ovs-vsctl set controller $bridge_name connection-mode=out-of-band
+
+# Set fail-mode to secure so that when the connection to the
+# controller is lost, OVS will not perform normal (traditional) L2/L3
+# functionality
+ovs-vsctl set bridge $bridge_name fail-mode=secure
+
+# Specify OpenFlow version
+ovs-vsctl set bridge $bridge_name protocols=OpenFlow10,OpenFlow12,OpenFlow13
+
+# Disable STP
+ovs-vsctl set Bridge $bridge_name stp_enable=false

--- a/bin/inception_revert.sh
+++ b/bin/inception_revert.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+# Usage: ./inception_revert.sh
+
+bridge_name=obr1
+
+# Deconnect from the controller
+ovs-vsctl del-controller $bridge_name
+
+# Delete fail-mode. When connection to the controller is lost,
+# The virtual switch will act like a traditional switch
+ovs-vsctl del-fail-mode $bridge_name
+
+# Clear Openflow protocols
+ovs-vsctl clear Bridge $bridge_name protocols
+
+# Enable STP
+ovs-vsctl set Bridge $bridge_name stp_enable=true
+ 
+# Delete all Openflow flows
+ovs-ofctl del-flows $bridge_name
+
+# Add a flow for normal operation
+ovs-ofctl add-flow $bridge_name "table=0, actions=NORMAL"


### PR DESCRIPTION
nodes

Usage:

On each worker node

To apply OpenFlow mode: "./inception_apply.sh <controller_ip>"

To revert to plain switch mode: "./inception_revert.sh"
