### PR TITLE
Store mappings in Zookeeper:

### DIFF
--- a/etc/ryu/inception.conf
+++ b/etc/ryu/inception.conf
@@ -7,3 +7,5 @@ ip_prefix=192.168
 zk_servers=127.0.0.1:2181
 
 zk_election_path='/election'
+
+zk_data_path='/data'

--- a/ryu/app/inception_arp.py
+++ b/ryu/app/inception_arp.py
@@ -3,12 +3,23 @@ Inception Cloud ARP module
 """
 import logging
 
+from oslo.config import cfg
+
+from ryu.lib.dpid import dpid_to_str
+from ryu.lib.dpid import str_to_dpid
+
 from ryu.ofproto import ether
 from ryu.lib.packet import packet
 from ryu.lib.packet import ethernet
 from ryu.lib.packet import arp
 
 LOGGER = logging.getLogger(__name__)
+
+CONF = cfg.CONF
+CONF.register_opts([
+    cfg.StrOpt('zk_data_path',
+               default='/data',
+               help="Path for storing all mappings")])
 
 
 class InceptionArp(object):
@@ -20,7 +31,9 @@ class InceptionArp(object):
         self.inception = inception
         # IP address -> MAC address: mapping from IP address to MAC address
         # of end hosts for address resolution
-        self.ip_to_mac = {}
+        # self.ip_to_mac = {}
+        self.ip_to_mac_zk = CONF.zk_data_path + '/ip_to_mac'
+        self.inception.zk_client.ensure_path(self.ip_to_mac_zk)
 
     def handle(self, event):
         # process only if it is ARP packet
@@ -47,14 +60,17 @@ class InceptionArp(object):
     def _do_arp_learning(self, event):
         """
         Learn IP => MAC mapping from a received ARP packet, update
-        self.ip_to_mac table
+        ip_to_mac table
         """
         msg = event.msg
 
         whole_packet = packet.Packet(msg.data)
         arp_header = whole_packet.get_protocols(arp.arp)[0]
-        if arp_header.src_ip not in self.ip_to_mac:
-            self.ip_to_mac[arp_header.src_ip] = arp_header.src_mac
+        ip_list = self.inception.zk_client.get_children(self.ip_to_mac_zk)
+        if arp_header.src_ip not in ip_list:
+            ip_path = self.ip_to_mac_zk + '/' + arp_header.src_ip
+            self.inception.zk_client.ensure_path(ip_path)
+            self.inception.zk_client.set(ip_path, arp_header.src_mac)
             LOGGER.info("Learn: (ip=%s) => (mac=%s)",
                         arp_header.src_ip, arp_header.src_mac)
 
@@ -74,7 +90,8 @@ class InceptionArp(object):
                     arp_header.src_ip, arp_header.dst_ip)
         # If entry not found, broadcast request
         # TODO(Chen): Buffering request? Not needed in a friendly environment
-        if arp_header.dst_ip not in self.ip_to_mac:
+        ip_list = self.inception.zk_client.get_children(self.ip_to_mac_zk)
+        if arp_header.dst_ip not in ip_list:
             LOGGER.info("Entry for (ip=%s) not found, broadcast ARP request",
                         arp_header.dst_ip)
             for dpid, dps_datapath in self.inception.dpset.dps.items():
@@ -82,25 +99,44 @@ class InceptionArp(object):
                     continue
                 ports = self.inception.dpset.get_ports(dpid)
                 # Sift out ports connecting to hosts but vxlan peers
-                vxlan_ports = [port_no for port_no in
-                    self.inception.dpid_to_conns[dpid].values()]
+                dpid_path = (
+                    self.inception.dpid_to_conns_zk + '/' +
+                    dpid_to_str(dpid)
+                    )
+                remote_ips = (
+                    self.inception.zk_client.get_children(dpid_path)
+                    )
+                remote_ports = []
+                for ip in remote_ips:
+                    remote_ip_path = dpid_path + '/' + ip
+                    remote_port, znode = (
+                        self.inception.zk_client.get(remote_ip_path)
+                        )
+                    remote_ports.append(remote_port)
+                vxlan_ports = [int(port_no) for port_no in remote_ports]
                 host_ports = [port.port_no for port in ports
-                    if port.port_no not in vxlan_ports]
+                              if port.port_no not in vxlan_ports]
                 actions_ports = [ofproto_parser.OFPActionOutput(port)
-                    for port in host_ports]
-                dps_datapath.send_msg(ofproto_parser.OFPPacketOut(
-                    datapath=dps_datapath,
-                    buffer_id=0xffffffff,
-                    in_port=ofproto.OFPP_LOCAL,
-                    data=msg.data,
-                    actions=actions_ports))
+                                 for port in host_ports]
+                dps_datapath.send_msg(
+                    ofproto_parser.OFPPacketOut(
+                        datapath=dps_datapath,
+                        buffer_id=0xffffffff,
+                        in_port=ofproto.OFPP_LOCAL,
+                        data=msg.data,
+                        actions=actions_ports
+                        )
+                    )
         # Entry exists
         else:
             # setup data forwarding flows
-            result_dst_mac = self.ip_to_mac[arp_header.dst_ip]
+            dst_mac_path = self.ip_to_mac_zk + '/' + arp_header.dst_ip
+            result_dst_mac, mac_znode = (
+                self.inception.zk_client.get(dst_mac_path)
+                )
             self.inception.setup_switch_fwd_flows(arp_header.src_mac,
                                                   result_dst_mac)
-            # construct ARP reply packet and send it to the host
+            # Construct ARP reply packet and send it to the host
             LOGGER.info("Hit: (dst_ip=%s) <=> (dst_mac=%s)",
                         arp_header.dst_ip, result_dst_mac)
 
@@ -117,13 +153,15 @@ class InceptionArp(object):
             packet_reply.add_protocol(arp_reply)
             packet_reply.serialize()
             actions_out = [ofproto_parser.OFPActionOutput(in_port)]
-            datapath.send_msg(ofproto_parser.OFPPacketOut(
-                datapath=datapath,
-                buffer_id=0xffffffff,
-                in_port=ofproto.OFPP_LOCAL,
-                data=packet_reply.data,
-                actions=actions_out
-            ))
+            datapath.send_msg(
+                ofproto_parser.OFPPacketOut(
+                    datapath=datapath,
+                    buffer_id=0xffffffff,
+                    in_port=ofproto.OFPP_LOCAL,
+                    data=packet_reply.data,
+                    actions=actions_out
+                    )
+                )
             LOGGER.info("Answer ARP reply to (host=%s) (mac=%s) on (port=%s) "
                         "on behalf of (ip=%s) (mac=%s)",
                         arp_reply.dst_ip, arp_reply.dst_mac, in_port,
@@ -139,10 +177,21 @@ class InceptionArp(object):
         arp_header = whole_packet.get_protocol(arp.arp)
         LOGGER.info("ARP reply: (ip=%s) answer (ip=%s)", arp_header.src_ip,
                     arp_header.dst_ip)
-        # if I know to whom to forward back this ARP reply
-        if arp_header.dst_mac in self.inception.mac_to_dpid_port:
-            dst_dpid, port = (self.inception.
-                mac_to_dpid_port[arp_header.dst_mac])
+        dst_mac_path = (
+            self.inception.mac_to_dpid_port_zk + '/' +
+            arp_header.dst_mac
+            )
+        if self.inception.zk_client.exists(dst_mac_path):
+            # if I know to whom to forward back this ARP reply
+            dst_mac_data_raw, dst_znode = (
+                self.inception.zk_client.get(dst_mac_path)
+                )
+            dst_mac_data = dst_mac_data_raw.split(',')
+            dst_dpid_str = dst_mac_data[0]
+            dst_dpid = str_to_dpid(dst_dpid_str)
+            port_str = dst_mac_data[1]
+            port = int(port_str)
+
             # setup data forwarding flows
             self.inception.setup_switch_fwd_flows(arp_header.src_mac,
                                                   arp_header.dst_mac)
@@ -151,12 +200,14 @@ class InceptionArp(object):
             dst_ofproto_parser = dst_datapath.ofproto_parser
             dst_ofproto = dst_datapath.ofproto
             actions_out = [dst_ofproto_parser.OFPActionOutput(port)]
-            dst_datapath.send_msg(dst_ofproto_parser.OFPPacketOut(
-                datapath=dst_datapath,
-                buffer_id=0xffffffff,
-                in_port=dst_ofproto.OFPP_LOCAL,
-                data=msg.data,
-                actions=actions_out
-            ))
+            dst_datapath.send_msg(
+                dst_ofproto_parser.OFPPacketOut(
+                    datapath=dst_datapath,
+                    buffer_id=0xffffffff,
+                    in_port=dst_ofproto.OFPP_LOCAL,
+                    data=msg.data,
+                    actions=actions_out
+                    )
+                )
             LOGGER.info("Forward ARP reply from (ip=%s) to (ip=%s) in buffer",
                         arp_header.src_ip, arp_header.dst_ip)

--- a/ryu/app/inception_dhcp.py
+++ b/ryu/app/inception_dhcp.py
@@ -6,6 +6,8 @@ import logging
 from ryu.ofproto import ether
 from ryu.ofproto import inet
 from ryu.lib.dpid import dpid_to_str
+from ryu.lib.dpid import str_to_dpid
+
 from ryu.lib.packet import packet
 from ryu.lib.packet import ethernet
 from ryu.lib.packet import ipv4
@@ -67,28 +69,39 @@ class InceptionDhcp(object):
                         "(port=%s)", dpid_to_str(self.server_switch),
                         self.server_port)
             datapath = self.inception.dpset.get(self.server_switch)
-            action_out = [datapath.ofproto_parser.OFPActionOutput(
-                self.server_port)]
-            datapath.send_msg(datapath.ofproto_parser.OFPPacketOut(
-                datapath=datapath,
-                buffer_id=0xffffffff,
-                in_port=datapath.ofproto.OFPP_LOCAL,
-                data=msg.data,
-                actions=action_out
-            ))
+            action_out = [
+                datapath.ofproto_parser.OFPActionOutput(self.server_port)
+                ]
+            datapath.send_msg(
+                datapath.ofproto_parser.OFPPacketOut(
+                    datapath=datapath,
+                    buffer_id=0xffffffff,
+                    in_port=datapath.ofproto.OFPP_LOCAL,
+                    data=msg.data,
+                    actions=action_out)
+                )
         # A packet received from server. Find out the mac address of
         # the client and forward the packet to it.
         elif udp_header.src_port == DHCP_SERVER_PORT:
-            dpid, port = self.inception.mac_to_dpid_port[ethernet_header.dst]
+            mac_path = (self.inception.mac_to_dpid_port_zk + '/' +
+                ethernet_header.dst)
+            mac_data_raw, data_znode = self.inception.zk_client.get(mac_path)
+            mac_data = mac_data_raw.split(',')
+            dpid_str = mac_data[0]
+            dpid = str_to_dpid(dpid_str)
+            port_str = mac_data[1]
+            port = int(port_str)
             LOGGER.info("Forward DHCP message to client (mac=%s) at "
                         "(switch=%s) (port=%s)", ethernet_header.dst,
                         dpid_to_str(dpid), port)
             datapath = self.inception.dpset.get(dpid)
             action_out = [datapath.ofproto_parser.OFPActionOutput(port)]
-            datapath.send_msg(datapath.ofproto_parser.OFPPacketOut(
-                datapath=datapath,
-                buffer_id=0xffffffff,
-                in_port=datapath.ofproto.OFPP_LOCAL,
-                data=msg.data,
-                actions=action_out
-            ))
+            datapath.send_msg(
+                datapath.ofproto_parser.OFPPacketOut(
+                    datapath=datapath,
+                    buffer_id=0xffffffff,
+                    in_port=datapath.ofproto.OFPP_LOCAL,
+                    data=msg.data,
+                    actions=action_out
+                    )
+                )


### PR DESCRIPTION
All dictionaries, except dpset, are stored remotely
in Zookeeper. dpset is stored locally and updated on
connection.
A dictionary dict with entries of the form:
key => value
is represented in the Zookeeper as a parent znode,
named "dict", followed by a number of child znodes,
each of which stands for a key:value pair, with the
znode's name being "key", and znode's data being "value".

For example, a dictionary dict with two entries:
{id1:name1, id2:name2}
is represented in Zookeeper as follows:
Parent znode: (name=dict, data=None)
Child znodes: (name=id1, data=name1);
              (name=id2, data=name2).
