### PR TITLE
Change the timing of data type cast

### DIFF
--- a/ryu/app/inception_dhcp.py
+++ b/ryu/app/inception_dhcp.py
@@ -38,7 +38,7 @@ class InceptionDhcp(object):
             LOGGER.warning("Found more than one DHCP server. Ignore others!")
             return
         self.inception.zk.set(DHCP_SWITCH_DPID, dpid)
-        self.inception.zk.set(DHCP_SWITCH_PORT, str(port))
+        self.inception.zk.set(DHCP_SWITCH_PORT, port)
 
     def handle(self, event):
         # process only if it is DHCP packet


### PR DESCRIPTION
Data type cast is changed to only happen when reading data out and
writing data to Ryu's built-in components (dpset, event, sendmsg,
etc).  This way, ZooKeeper data read/write deal only with
str. Hopefully this can make future coding easier.
