### PR TITLE
Eliminate ARP broadcast:

### DIFF
--- a/ryu/app/inception.py
+++ b/ryu/app/inception.py
@@ -397,14 +397,15 @@ class Inception(app_manager.RyuApp):
                         "(mac=%s)", dpid, ethernet_src)
         else:
             dpid_port_record, _ = self.zk.get(os.path.join(
-                i_conf.MAC_TO_DPID_PORT, ethernet_src))
+                                    i_conf.MAC_TO_DPID_PORT, ethernet_src))
             dpid_record, _ = i_util.str_to_tuple(dpid_port_record)
             # The host's switch changes, e.g., due to a VM live migration
             if dpid_record != dpid:
                 ip, _ = self.zk.get(os.path.join(i_conf.DPID_TO_IP, dpid))
                 dpid_port_new = i_util.tuple_to_str((dpid, in_port))
-                txn.set(os.path.join(i_conf.MAC_TO_DPID_PORT, ethernet_src),
-                        dpid_port_new)
+                txn.set_data(os.path.join(i_conf.MAC_TO_DPID_PORT,
+                                          ethernet_src),
+                             dpid_port_new)
                 LOGGER.info("Update: (mac=%s) => (switch=%s, port=%s)",
                             ethernet_src, dpid, in_port)
 

--- a/ryu/app/inception_dhcp.py
+++ b/ryu/app/inception_dhcp.py
@@ -44,12 +44,17 @@ class InceptionDhcp(object):
         self.inception.zk.set(i_conf.DHCP_SWITCH_DPID, dpid)
         self.inception.zk.set(i_conf.DHCP_SWITCH_PORT, port)
 
+    def get_server_info(self):
+        # Get tuple (dpid_of_dhcpserver, port_of_dhcpserver)
+        dhcp_switch_dpid, _ = self.inception.zk.get(i_conf.DHCP_SWITCH_DPID)
+        dhcp_switch_port, _ = self.inception.zk.get(i_conf.DHCP_SWITCH_PORT)
+        return (dhcp_switch_dpid, dhcp_switch_port)
+
     def handle(self, udp_header, ethernet_header, raw_data, txn):
         # Process DHCP packet
         LOGGER.info("Handle DHCP packet")
 
-        dhcp_switch_dpid, _ = self.inception.zk.get(i_conf.DHCP_SWITCH_DPID)
-        dhcp_switch_port, _ = self.inception.zk.get(i_conf.DHCP_SWITCH_PORT)
+        dhcp_switch_dpid, dhcp_switch_port = self.get_server_info()
 
         if not dhcp_switch_dpid or not dhcp_switch_port:
             LOGGER.warning("No DHCP server has been found!")


### PR DESCRIPTION
No ARP broadcast in the network at all.
The controller is supposed to collect
hosts' info through gratuitous ARP, when
hosts boot.
If an ARP request finds no matching entry
in the ip_to_mac dictionary, either the
requested host does not exist, or the
gratuitous arp has not arrived at the
controller. The requesting host should
try later.
