### PR TITLE
Multi-datacenter ARP

### DIFF
--- a/ryu/app/inception_conf.py
+++ b/ryu/app/inception_conf.py
@@ -65,12 +65,9 @@ DPID_TO_CONNS = os.path.join(CONF.zk_data, 'dpid_to_conns')
 # "port": port number of dpid connecting IP address.
 # dpid include gateway switches
 
-GATEWAY_TO_CONNS = os.path.join(CONF.zk_data, 'gateway_to_conns')
-# {gateway_dpid => {remote IP address => local port}}
-# Path in ZooKeeper, under which records the neighboring relations
-# of gateway switch.
-# "IP address": address of remote VMs.
-# "port": port number of gateway dpid connecting IP address.
+GATEWAY = os.path.join(CONF.zk_data, 'gateway')
+# Znode for storing gateway dpid
+# TODO(chen): Multiple gateways
 
 MAC_TO_DPID_PORT = os.path.join(CONF.zk_data, 'mac_to_dpid_port')
 # {MAC => (local dpid, local port)}

--- a/ryu/app/inception_rpc.py
+++ b/ryu/app/inception_rpc.py
@@ -31,24 +31,25 @@ class InceptionRpc(object):
 
     def __init__(self, inception):
         self.inception = inception
+        self.i_arp = inception.inception_arp
 
     def rpc_setup_inter_dcenter_flows(self, local_mac, remote_mac, txn=None):
         """Set up flows towards gateway switch"""
-        self.inception.setup_inter_dcenter_flows(local_mac, remote_mac,
+        self.inception.setup_inter_dcenter_flows(local_mac,
+                                                 remote_mac,
                                                  txn=None)
 
-    def do_remote_arp_learning(self, ip, mac, dcenter_id):
+    def rpc_arp_learning(self, ip, mac, dcenter_id):
         """Update ip_mac mapping"""
         mac_dcenter = i_util.tuple_to_str((mac, dcenter_id))
+        self.inception.ip_to_mac_dcenter[ip] = (mac, dcenter_id)
         self.inception.zk.create(
             os.path.join(i_conf.IP_TO_MAC_DCENTER, ip), mac_dcenter)
         LOGGER.info("Update remote ip_mac: (ip=%s) => (mac=%s, dcenter=%s)",
                     ip, mac, dcenter_id)
 
     def rpc_send_arp_reply(self, src_ip, src_mac, dst_ip, dst_mac, txn=None):
-        self.inception.inception_arp.send_arp_reply(src_ip, src_mac, dst_ip,
-                                                    dst_mac, txn)
+        self.i_arp.send_arp_reply(src_ip, src_mac, dst_ip, dst_mac, txn)
 
     def rpc_broadcast_arp_request(self, src_ip, src_mac, dst_ip, dpid):
-        self.inception.inception_arp.broadcast_arp_request(src_ip, src_mac,
-                                                           dst_ip, dpid)
+        self.i_arp.broadcast_arp_request(src_ip, src_mac, dst_ip, dpid)


### PR DESCRIPTION
1. ARP received by controller 1.
2. Local look-up.
3. Send arp reply to requesting node.
4. If requested node is local, set up
   intra-datacenter flows.
5. If requested node is in another datacenter
   which is controlled by controller 2,
   set up inter-datacenter flows locally,
   and use rpc to instruct controller 2 to
   set up inter-datacenter flows.
