### PR TITLE
VM migration

### DIFF
--- a/etc/ryu/inception.conf
+++ b/etc/ryu/inception.conf
@@ -14,6 +14,8 @@ zk_log_level=warning
 
 ip_prefix=192.168
 
-datacenter_id=1
+datacenter_id=0
+
+neighbor_dcenter_id=0
 
 remote_controller=127.0.0.1

--- a/ryu/app/inception_conf.py
+++ b/ryu/app/inception_conf.py
@@ -47,6 +47,9 @@ CONF.register_opts([
     cfg.StrOpt('datacenter_id',
                default='0',
                help="Datacenter identification"),
+    cfg.StrOpt('neighbor_dcenter_id',
+               default='0',
+               help="Neighbor datacenter identification"),
     cfg.StrOpt('remote_controller',
                default='127.0.0.1',
                help="IP address of remote controllers"),
@@ -69,21 +72,20 @@ GATEWAY = os.path.join(CONF.zk_data, 'gateway')
 # Znode for storing gateway dpid
 # TODO(chen): Multiple gateways
 
-MAC_TO_DPID_PORT = os.path.join(CONF.zk_data, 'mac_to_dpid_port')
-# {MAC => (local dpid, local port)}
-# Path in ZooKeeper, under which records the switch ("dpid") to
-# which a local "mac" connects, as well as the "port" of the
-# connection.
+MAC_TO_POSITION = os.path.join(CONF.zk_data, 'mac_to_position')
+# {MAC => (datacenter id, local dpid, local port)}
+# Path in ZooKeeper, under which records datacenter in which "MAC" lies,
+# the switch ("dpid") to which "MAC" connects, and "port" of the connection.
 
 MAC_TO_FLOWS = os.path.join(CONF.zk_data, 'mac_to_flows')
 # {MAC => {dpid => (True)}}
 # Path in ZooKeeper, under which record "dpid"s that has installed
 # a rule forwarding packets to "mac".
 
-IP_TO_MAC_DCENTER = os.path.join(CONF.zk_data, 'ip_to_mac_dcenter')
-# {IP address => (MAC address, Datacenter ID)}
+IP_TO_MAC = os.path.join(CONF.zk_data, 'ip_to_mac')
+# {IP address => MAC address}
 # Path in ZooKeeper, under which records mapping from IP address
-# to (MAC address, Datacenter ID) of end hosts for address resolution
+# to MAC address of end hosts for address resolution
 
 DHCP_SWITCH_DPID = os.path.join(CONF.zk_data, 'dhcp_switch_dpid')
 # Path in ZooKeeper, under which records the switch to which DHCP

--- a/ryu/app/inception_rpc.py
+++ b/ryu/app/inception_rpc.py
@@ -23,6 +23,7 @@ class InceptionRpc(object):
 
     def __init__(self, inception):
         self.inception = inception
+        self.zk = inception.zk
         self.i_arp = inception.inception_arp
 
     def rpc_setup_inter_dcenter_flows(self, local_mac, remote_mac):
@@ -32,10 +33,43 @@ class InceptionRpc(object):
 
     def rpc_arp_learning(self, ip, mac, dcenter):
         """Update remote ip_mac mapping"""
-        self.i_arp.update_arp_mapping(ip, mac, dcenter)
+        txn = self.zk.transaction()
+        self.i_arp.update_arp_mapping(ip, mac, dcenter, txn)
+        txn.commit()
 
     def rpc_send_arp_reply(self, src_ip, src_mac, dst_ip, dst_mac):
         self.i_arp.send_arp_reply(src_ip, src_mac, dst_ip, dst_mac)
 
     def rpc_broadcast_arp_request(self, src_ip, src_mac, dst_ip, dpid):
         self.i_arp.broadcast_arp_request(src_ip, src_mac, dst_ip, dpid)
+
+    def rpc_update_host_position(self, mac, dcenter):
+        txn = self.zk.transaction()
+        gateway_dpid = self.inception.gateway
+        gateway_port = self.inception.gateway_port
+        self.inception.update_host_position(mac, dcenter, gateway_dpid,
+                                            gateway_port, txn)
+        txn.commit()
+
+    def rpc_migration_flow_update(self, mac, dcenter):
+        """
+        Update flows towards a used-to-own mac,
+        mac has been migrated to the datacenter who calls the rpc
+        """
+        txn = self.zk.transaction()
+        _, dpid_old, port_old = self.inception.mac_to_position[mac]
+        # TODO(chen): A smarter way to get gateway through dcenter
+        # Now we assume there are only two datacenters
+        gateway_dpid = self.inception.gateway
+        gateway_port = self.inception.gateway_port
+        self.inception.handle_migration(mac, dpid_old, port_old,
+                                        gateway_dpid, gateway_port, txn)
+        self.inception.update_host_position(mac, dcenter, gateway_dpid,
+                                            gateway_port, txn)
+        txn.commit()
+
+    def rpc_gateway_flow_update(self, mac, dcenter):
+        """ Update gateway flow towards mac migrated to dcenter"""
+        # TODO(chen): Change gateway flow
+        # TODO(chen): Update new mac position
+        pass


### PR DESCRIPTION
We define two types of flow adjustment:
1. Same switch migration:
(dpid, port_old, mac) -> (dpid, port_new, mac)
(1) Modify flow at dpid towards mac.
2. Different switch migration:
(dpid_old, port_old, mac) ->
          (dpid_new, port_new, mac)
(1) Install/Update a new flow at dpid_new towards mac.
(2) Redirect all flows on dpidsother than dpid_new towards mac.
