### PR TITLE
Flow table size reduction

### DIFF
--- a/etc/ryu/inception.conf
+++ b/etc/ryu/inception.conf
@@ -14,8 +14,8 @@ zk_log_level=warning
 
 ip_prefix=192.168
 
-datacenter_id=0
+dcenter=0
 
-neighbor_dcenter_id=0
+neighbor_dcenter=0
 
 remote_controller=127.0.0.1

--- a/ryu/app/inception_conf.py
+++ b/ryu/app/inception_conf.py
@@ -71,17 +71,25 @@ CONF.register_opts([
 """
 Path in ZooKeeper, under which records a datacenter ("dcenter") in
 which a guest VM ("MAC") resides, the switch ("DPID") the VM is connected
-to, and the "port" of the connection.
+to, the "port" of the connection, and its virtual mac.
 
-{MAC => (dcenter, DPID, port)}
+{MAC => (dcenter, dpid, port, vmac)}
 """
 MAC_TO_POSITION = os.path.join(CONF.zk_data, 'mac_to_position')
 
 """
-Path in ZooKeeper, under which records each switch ("DPID") that has
-installed a flow which forwards data packets to VM ("MAC").
+Path in ZooKeeper, under which records the vm id numbers that
+have been assigned.
 
-{MAC => {DPID => (True)}}
+{dpid => {id => true}}
+"""
+DPID_TO_ID = os.path.join(CONF.zk_data, 'dpid_to_id')
+
+"""
+Path in ZooKeeper, under which records each switch ("DPID") that has
+installed a flow which forwards data packets to a specific MAC address.
+
+{MAC => {dpid => (True)}}
 """
 MAC_TO_FLOWS = os.path.join(CONF.zk_data, 'mac_to_flows')
 
@@ -92,3 +100,15 @@ VM's "MAC" address for address resolution protocol (ARP).
 {IP => MAC}
 """
 IP_TO_MAC = os.path.join(CONF.zk_data, 'ip_to_mac')
+
+"""
+Path in ZooKeeper, under which records mapping from switch ("DPID") to
+its virtual "MAC" address.
+
+{dpid => vmac}
+"""
+DPID_TO_VMAC = os.path.join(CONF.zk_data, 'dpid_to_vmac')
+
+DCENTER_MASK = "ff:ff:00:00:00:00"
+SWITCH_MASK = "ff:ff:ff:ff:00:00"
+VM_MASK = "ff:ff:ff:ff:ff:00"

--- a/ryu/app/inception_rpc.py
+++ b/ryu/app/inception_rpc.py
@@ -45,12 +45,12 @@ class InceptionRpc(object):
     def broadcast_arp_request(self, src_ip, src_mac, dst_ip, dpid):
         self.inception_arp.broadcast_arp_request(src_ip, src_mac, dst_ip, dpid)
 
-    def update_position(self, mac, dcenter):
+    def update_position(self, mac, dcenter, vmac):
         txn = self.zk.transaction()
         gateway_dpid = self.inception.gateway
         gateway_port = self.inception.gateway_port
         self.inception.update_position(mac, dcenter, gateway_dpid,
-                                       gateway_port, txn)
+                                       gateway_port, vmac, txn)
         txn.commit()
 
     def update_migration_flow(self, mac, dcenter):

--- a/ryu/app/inception_util.py
+++ b/ryu/app/inception_util.py
@@ -30,3 +30,52 @@ def str_to_tuple(data_string, sep=','):
 
     data_tuple = tuple(data_string.split(sep))
     return data_tuple
+
+
+def generate_vm_id(last_id, bound=65535):
+    """Generate a new vm_id,
+    00 is saved for switch"""
+    #TODO(chen): Avoid id conflict
+    return ((last_id + 1) % 65534 + 1)
+
+
+# TODO(chen): Class VMAC
+def create_swc_vmac(dcenter, switch_num):
+    """Generate MAC address prefix for switch based on
+    datacenter id and switch id.
+
+    Address form: xx:xx:yy:yy:00:00
+    xx:xx is converted from data center id
+    yy:yy is converted from switch id
+    """
+    if dcenter > 65535 and switch_num > 65535:
+        # Invalid numbers
+        return
+
+    dcenter_high = (dcenter >> 8) & 0xff
+    dcenter_low = dcenter & 0xff
+    dcenter_prefix = "%02x:%02x" % (dcenter_high, dcenter_low)
+
+    switch_high = (switch_num >> 8) & 0xff
+    switch_low = switch_num & 0xff
+    switch_suffix = ("%02x:%02x:00:00" % (switch_high, switch_low))
+    return ':'.join((dcenter_prefix, switch_suffix))
+
+
+def create_vm_vmac(switch_vmac, vm_id):
+    """Generate virtual MAC address of a VM"""
+
+    switch_prefix = get_swc_prefix(switch_vmac)
+    id_hex = vm_id & 0xff
+    id_suffix = "%02x" % id_hex
+    return ':'.join((switch_prefix, id_suffix, '00'))
+
+
+def get_swc_prefix(vmac):
+    """Extract switch prefix from virtual MAC address"""
+    return vmac[:11]
+
+
+def get_dc_prefix(vmac):
+    """Extract switch prefix from virtual MAC address"""
+    return vmac[:5]


### PR DESCRIPTION
We reduce the table size by creating virtual MAC address.
Each guest is assigned a virtual MAC address,
created by the controller upon connection.
The format of virtual MAC:
dcenter:switch:vm_id:00

Forwarding is based on prefix matching, like that of
IP routing.
